### PR TITLE
Add field mappings to match production database schema

### DIFF
--- a/app/models/course.model.js
+++ b/app/models/course.model.js
@@ -7,27 +7,36 @@ module.exports = (sequelize, Sequelize) => {
     },
     dept: {
       type: Sequelize.STRING,
-      allowNull: false
+      allowNull: false,
+      field: 'Dept'
     },
     courseNumber: {
       type: Sequelize.STRING,
-      allowNull: false
+      allowNull: false,
+      field: 'Course Number'
     },
     level: {
       type: Sequelize.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'Level'
     },
     hours: {
       type: Sequelize.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'Hours'
     },
     name: {
       type: Sequelize.STRING,
-      allowNull: false
+      allowNull: false,
+      field: 'Name'
     },
     description: {
-      type: Sequelize.TEXT
+      type: Sequelize.TEXT,
+      field: 'Description'
     }
+  }, {
+    tableName: 'courses',
+    timestamps: false
   });
 
   return Course;


### PR DESCRIPTION
- Map model fields to actual database column names with spaces
- Add timestamps: false since production DB doesn't have createdAt/updatedAt
- This fixes the mismatch between model expectations and DB structure